### PR TITLE
Experiment c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.vscode/
+.ipynb_checkpoints/
+__pycache__/
+
+data/sentences.continuation
+data/sentences.eval
+data/sentences.train
+runs/
+
+wordembeddings-dim100.word2vec

--- a/train.py
+++ b/train.py
@@ -20,7 +20,8 @@ tf.flags.DEFINE_string("vocab_file_path", "data/k_frequent_words.word2vec", "Pat
 # Model parameters
 tf.flags.DEFINE_integer("embedding_dimension", 100, "Dimensionality of word embeddings")
 tf.flags.DEFINE_integer("vocabulary_size", 20000, "Size of the vocabulary")
-tf.flags.DEFINE_integer("state_size", 512, "Size of the hidden LSTM state")
+tf.flags.DEFINE_integer("state_size", 1024, "Size of the hidden LSTM state")
+tf.flags.DEFINE_integer("output_size", 512, "Size of the downprojected output of the LSTM")
 tf.flags.DEFINE_integer("sentence_length", 30, "Length of each sentence fed to the LSTM")
 
 # Embedding parameters
@@ -97,7 +98,8 @@ with tf.Graph().as_default():
         # Initialize model
         lstm_language_model = LSTMLanguageModel(vocabulary_size=FLAGS.vocabulary_size,
                                                 embedding_dimensions=FLAGS.embedding_dimension,
-                                                state_size=FLAGS.state_size)
+                                                state_size=FLAGS.state_size,
+                                                output_size=FLAGS.output_size)
 
         # Training step
         global_step = tf.Variable(0, name="global_step", trainable=False)


### PR DESCRIPTION
This branch implements Experiment C of the hand-out:
I changed the lstm model to accept one more input "output_size". If output_size == state_size, the lstm model will work exactly as before. If output_size < state_size, I introduce a new tf variable weights_downproject of dimension state_size x output_size. I will apply this weight matrix to the output before applying the usual softmax. This way, we can have a hidden state of size 1024 which is downprojected to size 512 before applying the softmax.